### PR TITLE
fix cicd process for beta tags and ignore README.md file

### DIFF
--- a/.github/workflows/dockerByPR.yml
+++ b/.github/workflows/dockerByPR.yml
@@ -8,6 +8,8 @@ on:
     paths-ignore:
       - 'docs/**'
       - '.github/**'
+      - 'README.md'
+      - 'saveenv.sh'
 
 jobs:
 
@@ -58,7 +60,6 @@ jobs:
       ACR_REG: 'gelatoappsvc'
       ACR_REPO: 'gelatoappsvc.azurecr.io'
       ACR_IMAGE: 'helium-java'
-      ACR_TAG: 'stable'
     steps:
       - uses: actions/checkout@v1
       - name: acr-push-build
@@ -67,14 +68,17 @@ jobs:
           #    SERVICE_PRINCIPAL  - your SP Client ID that has ACR Push IAM role
           #    SERVICE_PRINCIPAL_PASSWORD   - the personal access token for the SP Client id
           #    TENANT  - The tenant ID of the subscription of the ACR
-
-
-          echo "Building Docker image ${ACR_REPO}/${ACR_IMAGE}:${ACR_TAG} from ${GITHUB_REPOSITORY} on ${{ github.ref }}; and pushing it to ${ACR_REG} Azure Container Registry"
-          az login --service-principal -u ${{ secrets.SERVICE_PRINCIPAL }} -p ${{ secrets.SERVICE_PRINCIPAL_SECRET }} --tenant ${{ secrets.TENANT }}
-
+          
           # Strip git ref prefix from version
           VERSION=$(echo "${{ github.head_ref }}" | sed -e 's,.*/\(.*\),\1,')
           echo $VERSION
+
+          echo "Building Docker image ${ACR_REPO}/${ACR_IMAGE}:dev-${VERSION} from ${GITHUB_REPOSITORY} on ${{ github.ref }}; and pushing it to ${ACR_REG} Azure Container Registry"
+          
+          # Use AZ Login with Service Principal Authentication
+          az login --service-principal -u ${{ secrets.SERVICE_PRINCIPAL }} -p ${{ secrets.SERVICE_PRINCIPAL_SECRET }} --tenant ${{ secrets.TENANT }}
+
+          # Push to ACR for Build and Push
           az acr build -r ${ACR_REG} -f Dockerfile -t ${ACR_REPO}/${ACR_IMAGE}:dev-${VERSION} https://github.com/${GITHUB_REPOSITORY}.git#${{ github.ref }}
 
 

--- a/.github/workflows/dockerCI.yml
+++ b/.github/workflows/dockerCI.yml
@@ -8,6 +8,8 @@ on:
     paths-ignore:
       - 'docs/**'
       - '.github/**'
+      - 'README.md'
+      - 'savenv.sh'
 
     tags:
       - v*
@@ -55,11 +57,14 @@ jobs:
         
           # Strip "v" prefix from tag name
           VERSION=$(echo $VERSION | sed -e 's/^v//')
-  
+
+          # tag the image with :beta, :Version and :stable
+          docker tag image $IMAGE_ID:beta 
           docker tag image $IMAGE_ID:$VERSION
           docker tag image $IMAGE_ID:stable
+
         else
-          # tag the image with :beta
+          # tag the image with :beta only if no tag
           docker tag image $IMAGE_ID:beta
         fi
 
@@ -83,7 +88,7 @@ jobs:
           #    TENANT  - The tenant ID of the subscription of the ACR
 
 
-          echo "Building Docker image ${ACR_REPO}/${ACR_IMAGE}:${ACR_TAG} from ${GITHUB_REPOSITORY} on ${{ github.ref }}; and pushing it to ${ACR_REG} Azure Container Registry"
+          echo "Building Docker image ${ACR_REPO}/${ACR_IMAGE} from ${GITHUB_REPOSITORY} on ${{ github.ref }}; and pushing it to ${ACR_REG} Azure Container Registry"
           az login --service-principal -u ${{ secrets.SERVICE_PRINCIPAL }} -p ${{ secrets.SERVICE_PRINCIPAL_SECRET }} --tenant ${{ secrets.TENANT }}
           
           if [[ "${{ github.ref }}" == "refs/tags/"* ]]
@@ -95,7 +100,7 @@ jobs:
           # Strip "v" prefix from tag name
             VERSION=$(echo $VERSION | sed -e 's/^v//')
 
-            az acr build -r ${ACR_REG} -f Dockerfile -t ${ACR_REPO}/${ACR_IMAGE}:${VERSION} -t ${ACR_REPO}/${ACR_IMAGE}:${ACR_TAG} https://github.com/${GITHUB_REPOSITORY}.git#${{ github.ref }}
+            az acr build -r ${ACR_REG} -f Dockerfile -t ${ACR_REPO}/${ACR_IMAGE}:${VERSION} -t ${ACR_REPO}/${ACR_IMAGE}:${ACR_TAG} -t ${ACR_REPO}/${ACR_IMAGE}:beta https://github.com/${GITHUB_REPOSITORY}.git#${{ github.ref }}
           else
             az acr build -r ${ACR_REG} -f Dockerfile -t ${ACR_REPO}/${ACR_IMAGE}:beta https://github.com/${GITHUB_REPOSITORY}.git#${{ github.ref }}
           fi


### PR DESCRIPTION
## Type of PR

- [ ] Documentation changes
- [ ] Code changes
- [ ] Test changes
- [ x ] CI-CD changes
- [ ] GitHub Template changes

## Purpose of PR
bugfix for image tagging on tag of commit. Also ignored README.md and saveenv.sh at the root of the directory as these are supporting docs that should not cause a build.
## Review notes
Tested on private fork and repos. Based on tag of commit the CI ran and 3 images were written with same SHA tag
Reference [evillgenius/helium-java](https://hub.docker.com/repository/registry-1.docker.io/evillgenius/helium-java/tags?page=1) for proof
## Issues Closed or Referenced
Closes #39 

## NOTES
This change will not cause a build as it only changes files in an ignored path.