### PR TITLE
Fixed a broken command in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ export He_Cosmos_MoviesCol=movies
 az cosmosdb create -g $He_Cosmos_RG -n $He_Name
 
 # create the database
-az cosmosdb sql database create -a $He_Name --n $He_Cosmos_DB -g $He_Cosmos_RG
+az cosmosdb sql database create -a $He_Name -n $He_Cosmos_DB -g $He_Cosmos_RG
 
 # create the containers
 # 400 is the minimum RUs
@@ -169,6 +169,7 @@ export dev_Object_Id=$(az ad user show --id {developer email address} --query ob
 
 # grant Key Vault access to each developer (optional)
 az keyvault set-policy -n $He_Name --secret-permissions get list --key-permissions get list --object-id $dev_Object_Id
+
 ```
 
 Run the application locally
@@ -179,6 +180,7 @@ KeyVault MSI does not work locally, there is a CSE feedback issue filed on the s
 To get KeyVault working locally we would need to go thru clear text route, for that update the clientid and clientkey by uncommenting these lines in application.properties and populating clientid and clientkey
 
 ```bash
+
 #azure.keyvault.uri=https://{kvurl}.vault.azure.net/
 #azure.keyvault.client-id={client_id}
 #azure.keyvault.client-key={client_key}

--- a/README.md
+++ b/README.md
@@ -153,8 +153,7 @@ az keyvault create -g $He_App_RG -n $He_Name
 az keyvault secret set -o table --vault-name $He_Name --name "azure-cosmosdb-uri" --value $He_Cosmos_URL
 az keyvault secret set -o table --vault-name $He_Name --name "azure-cosmosdb-key" --value $He_Cosmos_RO_Key
 az keyvault secret set -o table --vault-name $He_Name --name "azure-cosmosdb-database" --value $He_Cosmos_DB
-az keyvault secret set -o table --vault-name $He_Name --name "azure-cosmosdb-coll" --value $He_Cosmos_Col
-
+az keyvault secret set -o table --vault-name $He_Name --name "azure-cosmosdb-coll" --value $He_Cosmos_MoviesCol
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ export He_Cosmos_MoviesCol=movies
 az cosmosdb create -g $He_Cosmos_RG -n $He_Name
 
 # create the database
-az cosmosdb sql database create -d $He_Cosmos_DB -g $He_Cosmos_RG -n $He_Name
+az cosmosdb sql database create -a $He_Name --n $He_Cosmos_DB -g $He_Cosmos_RG
 
 # create the containers
 # 400 is the minimum RUs
@@ -169,20 +169,25 @@ export dev_Object_Id=$(az ad user show --id {developer email address} --query ob
 
 # grant Key Vault access to each developer (optional)
 az keyvault set-policy -n $He_Name --secret-permissions get list --key-permissions get list --object-id $dev_Object_Id
-
+```
 
 Run the application locally
 
 # IMP: security hole in keyvault MSI
-KeyVault MSI does not work locally , there is a CSE feedback issue filed on the same
+KeyVault MSI does not work locally, there is a CSE feedback issue filed on the same
 
 To get KeyVault working locally we would need to go thru clear text route, for that update the clientid and clientkey by uncommenting these lines in application.properties and populating clientid and clientkey
+
+```bash
 #azure.keyvault.uri=https://{kvurl}.vault.azure.net/
 #azure.keyvault.client-id={client_id}
 #azure.keyvault.client-key={client_key}
 
-```bash
+```
 
+Once you are done with the above, you should be able to build and test locally with one of the following commands
+
+```bash
 # run locally with unit tests
 mvn clean package
 


### PR DESCRIPTION
## Type of PR

- [x] Documentation changes


## Purpose of PR
One of the commands to create the keyvault secret was not working because of a typo in the shell variable name

## Review notes

## Issues Closed or Referenced

- Closes #43  (this will automatically close the issue when the PR closes)
- References #212 (this references the issue but does not close with PR)
