### PR TITLE
update CI to tag image with beta instead of dev

### DIFF
--- a/.github/workflows/dockerByPR.yml
+++ b/.github/workflows/dockerByPR.yml
@@ -58,8 +58,8 @@ jobs:
   acr-build-push-version:
     runs-on: ubuntu-latest
     env:
-      ACR_REG: 'devshop'
-      ACR_REPO: 'devshop.azurecr.io'
+      ACR_REG: 'heliume2e'
+      ACR_REPO: 'heliume2e.azurecr.io'
       ACR_IMAGE: 'helium-java'
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/dockerCI.yml
+++ b/.github/workflows/dockerCI.yml
@@ -60,15 +60,15 @@ jobs:
           VERSION=$(echo $VERSION | sed -e 's/^v//')
 
           # tag the image with :beta, :Version and :stable
-          docker tag image $IMAGE_ID:dev 
-          #docker tag image $IMAGE_ID:beta
+          #docker tag image $IMAGE_ID:dev 
+          docker tag image $IMAGE_ID:beta
           docker tag image $IMAGE_ID:$VERSION
           docker tag image $IMAGE_ID:stable
 
         else
           # tag the image with :beta only if no tag
-          #docker tag image $IMAGE_ID:beta
-          docker tag image $IMAGE_ID:dev
+          docker tag image $IMAGE_ID:beta
+          #docker tag image $IMAGE_ID:dev
         fi
 
         # Push to the repo

--- a/.github/workflows/dockerCI.yml
+++ b/.github/workflows/dockerCI.yml
@@ -77,8 +77,8 @@ jobs:
   acr-build-push-version:
     runs-on: ubuntu-latest
     env:
-      ACR_REG: 'devshop'
-      ACR_REPO: 'devshop.azurecr.io'
+      ACR_REG: 'heliume2e'
+      ACR_REPO: 'heliume2e.azurecr.io'
       ACR_IMAGE: 'helium-java'
       ACR_TAG: 'stable'
     steps:


### PR DESCRIPTION
## Type of PR

- [ ] Documentation changes
- [ ] Code changes
- [ ] Test changes
- [X] CI-CD changes
- [ ] GitHub Template changes

## Purpose of PR
Change CI/CD to match csharp and typescript to prepare for push to e2e prod environment. 
## Review notes

## Issues Closed or Referenced


- References #174  (this references the issue but does not close with PR)
