### PR TITLE
Error response standardization for getActor and getMovie

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,14 +70,7 @@
                 </exclusion>
             </exclusions>
         </dependency>
-        <!--
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-devtools</artifactId>
-            <scope>runtime</scope>
-            <optional>true</optional>
-        </dependency>
-        -->
+
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-configuration-processor</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -70,13 +70,14 @@
                 </exclusion>
             </exclusions>
         </dependency>
-
+        <!--
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-devtools</artifactId>
             <scope>runtime</scope>
             <optional>true</optional>
         </dependency>
+        -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-configuration-processor</artifactId>

--- a/src/main/java/com/microsoft/cse/helium/app/controllers/ActorsController.java
+++ b/src/main/java/com/microsoft/cse/helium/app/controllers/ActorsController.java
@@ -47,7 +47,8 @@ public class ActorsController extends Controller {
       return actorsDao
           .getActorById(actorId)
           .map(savedActor -> ResponseEntity.ok(savedActor))
-          .switchIfEmpty(Mono.defer(() -> Mono.just(ResponseEntity.notFound().build())));
+          .switchIfEmpty(Mono.defer(() -> 
+            Mono.error(new ResponseStatusException(HttpStatus.NOT_FOUND, "Actor not found"))));
     } else {
       logger.error("Invalid Actor ID parameter " + actorId);
 

--- a/src/main/java/com/microsoft/cse/helium/app/controllers/ActorsController.java
+++ b/src/main/java/com/microsoft/cse/helium/app/controllers/ActorsController.java
@@ -37,22 +37,23 @@ public class ActorsController extends Controller {
       value = "/{id}",
       method = RequestMethod.GET,
       produces = MediaType.APPLICATION_JSON_VALUE)
-  public Mono<ResponseEntity<Actor>> getActor(
+  @SuppressWarnings("raw")
+  public Mono<ResponseEntity<?>> getActor(
       @ApiParam(value = "The ID of the actor to look for", example = "nm0000002", required = true)
       @PathVariable("id")
           String actorId) {
     if (validator.isValidActorId(actorId)) {
-      return actorsDao
-          .getActorById(actorId)
-          .map(savedActor -> ResponseEntity.ok(savedActor))
-          .defaultIfEmpty(ResponseEntity.notFound().build());
+      Mono<Actor> actorResponse = actorsDao.getActorById(actorId);
+      Mono<ResponseEntity<?>> response = 
+          actorResponse.map(actor -> new ResponseEntity<>(actor, HttpStatus.OK));
+      return response;
     } else {
       logger.error("Invalid Actor ID parameter " + actorId);
       return Mono.justOrEmpty(
           ResponseEntity.badRequest()
               .contentType(MediaType.TEXT_PLAIN)
-              .header("Invalid Actor ID parameter")
-              .build());
+              .body("Invalid Actor ID parameter")
+              );
     }
   }
 

--- a/src/main/java/com/microsoft/cse/helium/app/controllers/Controller.java
+++ b/src/main/java/com/microsoft/cse/helium/app/controllers/Controller.java
@@ -36,14 +36,15 @@ public class Controller {
       IDao dataObject) {
 
     Map<String,Object> queryParams = new HashMap<String, Object>();
+    HttpHeaders headers = new HttpHeaders();
+    headers.setContentType(MediaType.TEXT_PLAIN);
 
     if (query.isPresent()) {
       if (validator.isValidSearchQuery(query.get())) {
         queryParams.put("q", query.get().trim().toLowerCase().replace("'", "''"));
       } else {
         logger.error("Invalid q (search) parameter");
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.TEXT_PLAIN);
+
         return new ResponseEntity<>(
             "Invalid q (search) parameter", headers, HttpStatus.BAD_REQUEST);
       }
@@ -53,8 +54,7 @@ public class Controller {
     if (pageNumber.isPresent()) {
       if (!validator.isValidPageNumber(pageNumber.get())) {
         logger.error("Invalid PageNumber parameter");
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.TEXT_PLAIN);
+
         return new ResponseEntity<>(
             "Invalid PageNumber parameter", headers, HttpStatus.BAD_REQUEST);
       } else {
@@ -66,8 +66,7 @@ public class Controller {
     if (pageSize.isPresent()) {
       if (!validator.isValidPageSize(pageSize.get())) {
         logger.error("Invalid PageSize parameter");
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.TEXT_PLAIN);
+
         return new
             ResponseEntity<>("Invalid PageSize parameter", headers, HttpStatus.BAD_REQUEST);
       } else {
@@ -103,6 +102,8 @@ public class Controller {
 
     Map<String,Object> queryParams = new HashMap<String, Object>();
     String q = null;
+    HttpHeaders headers = new HttpHeaders();
+    headers.setContentType(MediaType.TEXT_PLAIN);
 
     if (query.isPresent()) {
       if (validator.isValidSearchQuery(query.get())) {
@@ -110,8 +111,7 @@ public class Controller {
         queryParams.put("q",q);
       } else {
         logger.error("Invalid q (search) parameter");
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.TEXT_PLAIN);
+
         return new ResponseEntity<>(
             "Invalid q (search) parameter", headers, HttpStatus.BAD_REQUEST);
       }
@@ -121,8 +121,7 @@ public class Controller {
     if (pageNumber.isPresent()) {
       if (!validator.isValidPageNumber(pageNumber.get())) {
         logger.error("Invalid PageNumber parameter");
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.TEXT_PLAIN);
+
         return new ResponseEntity<>(
             "Invalid PageNumber parameter", headers, HttpStatus.BAD_REQUEST);
       } else {
@@ -134,8 +133,7 @@ public class Controller {
     if (pageSize.isPresent()) {
       if (!validator.isValidPageSize(pageSize.get())) {
         logger.error("Invalid PageSize parameter");
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.TEXT_PLAIN);
+
         return new
             ResponseEntity<>("Invalid PageSize parameter", headers, HttpStatus.BAD_REQUEST);
       } else {
@@ -147,8 +145,7 @@ public class Controller {
     if (genre.isPresent()) {
       if (!validator.isValidGenre(genre.get())) {
         logger.error("Invalid Genre parameter");
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.TEXT_PLAIN);
+
         return new
             ResponseEntity<>("Invalid Genre parameter", headers, HttpStatus.BAD_REQUEST);
       } else {
@@ -161,8 +158,7 @@ public class Controller {
     if (year.isPresent()) {
       if (!validator.isValidYear(year.get())) {
         logger.error("Invalid Year parameter");
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.TEXT_PLAIN);
+
         return new
             ResponseEntity<>("Invalid Year parameter", headers, HttpStatus.BAD_REQUEST);
       } else {
@@ -175,8 +171,7 @@ public class Controller {
     if (rating.isPresent()) {
       if (!validator.isValidRating(rating.get())) {
         logger.error("Invalid Rating parameter");
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.TEXT_PLAIN);
+
         return new
             ResponseEntity<>("Invalid Rating parameter", headers, HttpStatus.BAD_REQUEST);
       } else {
@@ -189,8 +184,7 @@ public class Controller {
     if (actorId.isPresent()) {
       if (!validator.isValidActorId(actorId.get())) {
         logger.error("Invalid Actor ID parameter");
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.TEXT_PLAIN);
+
         return new ResponseEntity<>(
             "Invalid Actor ID parameter", headers, HttpStatus.BAD_REQUEST);
       } else {

--- a/src/main/java/com/microsoft/cse/helium/app/controllers/MoviesController.java
+++ b/src/main/java/com/microsoft/cse/helium/app/controllers/MoviesController.java
@@ -44,7 +44,8 @@ public class MoviesController extends Controller {
       return moviesDao
           .getMovieById(movieId)
           .map(savedMovie -> ResponseEntity.ok(savedMovie))
-          .switchIfEmpty(Mono.defer(() -> Mono.just(ResponseEntity.notFound().build())));
+          .switchIfEmpty(Mono.defer(() -> 
+            Mono.error(new ResponseStatusException(HttpStatus.NOT_FOUND, "Movie not found"))));
     } else {
       logger.error("Invalid Movie ID parameter" + movieId);
 

--- a/src/main/java/com/microsoft/cse/helium/app/controllers/MoviesController.java
+++ b/src/main/java/com/microsoft/cse/helium/app/controllers/MoviesController.java
@@ -18,6 +18,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
 import reactor.core.publisher.Mono;
 
 /** MovieController. */
@@ -43,14 +44,12 @@ public class MoviesController extends Controller {
       return moviesDao
           .getMovieById(movieId)
           .map(savedMovie -> ResponseEntity.ok(savedMovie))
-          .defaultIfEmpty(ResponseEntity.notFound().build());
+          .switchIfEmpty(Mono.defer(() -> Mono.just(ResponseEntity.notFound().build())));
     } else {
       logger.error("Invalid Movie ID parameter" + movieId);
-      return Mono.justOrEmpty(
-          ResponseEntity.badRequest()
-              .contentType(MediaType.TEXT_PLAIN)
-              .header("Invalid Movie ID parameter")
-              .build());
+
+      return Mono.error(new ResponseStatusException(
+        HttpStatus.BAD_REQUEST, "Invalid Movie ID parameter"));
     }
   }
 

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -36,3 +36,4 @@ helium.keyvault.secretName =MySecret
 management.endpoints.web.base-path=/
 management.endpoints.web.path-mapping.health=healthz
 
+server.error.include-stacktrace=never


### PR DESCRIPTION
## Type of PR

- [ ] Documentation changes
- [X] Code changes
- [ ] Test changes
- [ ] CI-CD changes
- [ ] GitHub Template changes

## Purpose of PR
This update contains:
 * prevent the stack trace from returning to the client
 * proper error codes with body content for getActor and getMovie
 * standardizes the returns for the two error branches in the code

## Review notes
Since the errors for those two methods will return application/json it will cause webvalidate (master) to fail on these calls from running bad.json:

/api/actors/ab12345             ContentType: application/json Expected: text/plain
/api/actors/tt12345             ContentType: application/json Expected: text/plain
/api/actors/NM12345             ContentType: application/json Expected: text/plain
/api/actors/nm123               ContentType: application/json Expected: text/plain
/api/actors/nmabcde             ContentType: application/json Expected: text/plain
/api/actors/nm00000             ContentType: application/json Expected: text/plain
/api/actors/nm12345             ContentType: application/json Expected: text/plain
/api/movies/ab12345             ContentType: application/json Expected: text/plain
/api/movies/nm12345             ContentType: application/json Expected: text/plain
/api/movies/TT12345             ContentType: application/json Expected: text/plain
/api/movies/tt123               ContentType: application/json Expected: text/plain

## Issues Closed or Referenced

- Closes #173 
- Closes #180 

