### PR TITLE
Update the Dockerfile to create home directory for helium user 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,9 +20,12 @@ FROM  openjdk:8-jre-alpine AS release
 ARG build_ver
 ENV HOME=/app
 WORKDIR $HOME
+
 # Create a user
 RUN addgroup -g 4120 -S helium && \
-    adduser -u 4120 -S helium -G helium
+    adduser -u 4120 -S helium -G helium && \
+    mkdir -p /home/helium && \
+    chown -R helium:helium /home/helium
 USER helium
 
 #Note: Every time we update helium version, we must update the jar version below


### PR DESCRIPTION
## Type of PR

- [ ] Documentation changes
- [X] Code changes
- [ ] Test changes
- [ ] CI-CD changes
- [ ] GitHub Template changes

## Purpose of PR
Creating the $HOME/.azure for helium user in the Docker container so we can mount the .azure directory from the user running the container into it. Needed to run the container in CLI mode.

## Review notes

## Issues Closed or Referenced

- References #141  (this references the issue but does not close with PR)
