### PR TITLE
Moving partition key method to model classes

### DIFF
--- a/src/main/java/com/cse/helium/app/dao/ActorsDao.java
+++ b/src/main/java/com/cse/helium/app/dao/ActorsDao.java
@@ -41,7 +41,7 @@ public class ActorsDao extends BaseCosmosDbDao implements IDao {
     }
     
     return getContainer()
-            .getItem(actorId, utils.getPartitionKey(actorId))
+            .getItem(actorId, Actor.getPartitionKey(actorId))
             .read()
             .flatMap(
                 cosmosItemResponse -> 

--- a/src/main/java/com/cse/helium/app/dao/BaseCosmosDbDao.java
+++ b/src/main/java/com/cse/helium/app/dao/BaseCosmosDbDao.java
@@ -8,7 +8,6 @@ import com.azure.data.cosmos.FeedResponse;
 import com.azure.data.cosmos.SqlQuerySpec;
 import com.cse.helium.app.Constants;
 import com.cse.helium.app.services.configuration.IConfigurationService;
-import com.cse.helium.app.utils.CommonUtils;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.microsoft.azure.spring.data.cosmosdb.core.convert.ObjectMapperFactory;
@@ -23,8 +22,6 @@ public class BaseCosmosDbDao {
   private static final Logger logger = LogManager.getLogger(BaseCosmosDbDao.class);
 
   @Autowired ApplicationContext context;
-
-  @Autowired CommonUtils utils;
 
   protected IConfigurationService configurationService;
   protected String cosmosContainer = "";

--- a/src/main/java/com/cse/helium/app/dao/MoviesDao.java
+++ b/src/main/java/com/cse/helium/app/dao/MoviesDao.java
@@ -37,7 +37,7 @@ public class MoviesDao extends BaseCosmosDbDao implements IDao {
   /** getMovieByIdSingleRead. */
   public Mono<Movie> getMovieById(String movieId) {
     return getContainer()
-            .getItem(movieId, utils.getPartitionKey(movieId))
+            .getItem(movieId, Movie.getPartitionKey(movieId))
             .read()
             .flatMap(
                 cosmosItemResponse -> 

--- a/src/main/java/com/cse/helium/app/models/Actor.java
+++ b/src/main/java/com/cse/helium/app/models/Actor.java
@@ -6,6 +6,7 @@ import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import net.minidev.json.annotate.JsonIgnore;
+import org.springframework.util.StringUtils;
 
 /**
  * Actor.
@@ -49,5 +50,18 @@ public class Actor extends ActorBase {
         + ", movies=" + movies
         + ", deathYear=" + deathYear
         + "}";
+  }
+
+  /**
+   * GetPartitionKey.
+   */
+  public static String getPartitionKey(String id) {
+    // validate id
+    if (!StringUtils.isEmpty(id) && id.length() > 5
+        && StringUtils.startsWithIgnoreCase(id, "nm")) {
+      int idInt = Integer.parseInt(id.substring(2));
+      return String.valueOf(idInt % 10);
+    }
+    throw new IllegalArgumentException("Invalid Partition Key");
   }
 }

--- a/src/main/java/com/cse/helium/app/models/Movie.java
+++ b/src/main/java/com/cse/helium/app/models/Movie.java
@@ -8,6 +8,7 @@ import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import net.minidev.json.annotate.JsonIgnore;
+import org.springframework.util.StringUtils;
 
 /**
  * Movie.
@@ -46,5 +47,18 @@ public class Movie extends MovieBase {
 
   public Movie(){
     // default constructor
+  }
+
+  /**
+   * GetPartitionKey.
+   */
+  public static String getPartitionKey(String id) {
+    // validate id
+    if (!StringUtils.isEmpty(id) && id.length() > 5
+        && StringUtils.startsWithIgnoreCase(id, "tt")) {
+      int idInt = Integer.parseInt(id.substring(2));
+      return String.valueOf(idInt % 10);
+    }
+    throw new IllegalArgumentException("Invalid Partition Key");
   }
 }

--- a/src/main/java/com/cse/helium/app/utils/CommonUtils.java
+++ b/src/main/java/com/cse/helium/app/utils/CommonUtils.java
@@ -13,7 +13,6 @@ import org.apache.logging.log4j.core.config.Configurator;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.core.env.SimpleCommandLinePropertySource;
 import org.springframework.stereotype.Component;
-import org.springframework.util.StringUtils;
 
 /**
  * CommonUtils.
@@ -21,18 +20,8 @@ import org.springframework.util.StringUtils;
 @Component
 public class CommonUtils {
 
-  /**
-   * GetPartitionKey.
-   */
-
-  public String getPartitionKey(String id) {
-    // validate id
-    if (!StringUtils.isEmpty(id) && id.length() > 5 && StringUtils.startsWithIgnoreCase(id, "tt")
-        || StringUtils.startsWithIgnoreCase(id, "nm")) {
-      int idInt = Integer.parseInt(id.substring(2));
-      return String.valueOf(idInt % 10);
-    }
-    throw new IllegalArgumentException("Invalid Partition Key");
+  private CommonUtils() {
+    // disable constructor for utility class
   }
 
   /**


### PR DESCRIPTION
# Type of PR

- [ ] Documentation changes
- [x] Code changes
- [ ] Test changes
- [ ] CI-CD changes
- [ ] GitHub Template changes

## Purpose of PR
Moving GetPartitionKey() method to model classes so it can be different based on the entity.

## Validation

- [x] Unit tests ran successfully
- [ ] Update documentation or issue referenced above

## Issues Closed or Referenced

- References https://github.com/retaildevcrews/helium/issues/537
